### PR TITLE
Fixing a few issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ VOLUME /export/easybuild
 VOLUME /software/easybuild-develop
 
 USER root
-RUN yum -y install python-keyring zlib-devel openssl-devel libibverbs-devel unzip rpm-build
+RUN yum -y install python-keyring zlib-devel openssl-devel libibverbs-devel unzip rpm-build python-setuptools
 
 USER easybuild
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ docker-easybuild-centos6
 This is just [EasyBuild](https://hpcugent.github.io/easybuild/) in a CentOS image. When you start it up eb should be in your path by default.
 
 ```
-$ docker run --user="build" -ti rjeschmi/easybuild-centos6 /bin/bash
+$ docker run --user="easybuild" -ti rjeschmi/easybuild-centos6 /bin/bash
 ```
 
 The --rm option removes the container when it exits. You will lose all your work, but if you were just testing something that is probably ok.

--- a/build/z99_StdEnv.sh
+++ b/build/z99_StdEnv.sh
@@ -1,7 +1,6 @@
-
-export MODULEPATH=$(/software/Lmod/lmod/lmod/libexec/addto --append MODULEPATH /software/easybuild-develop/modulefiles)
-export MODULEPATH=$(/software/Lmod/lmod/lmod/libexec/addto --append MODULEPATH /software/easybuild/modules/all)
-export MODULEPATH=$(/software/Lmod/lmod/lmod/libexec/addto --append MODULEPATH /export/easybuild/modules/all)
+export MODULEPATH=$(/easybuild/deps/lmod/lmod/libexec/addto --append MODULEPATH /software/easybuild-develop/modulefiles)
+export MODULEPATH=$(/easybuild/deps/lmod/lmod/libexec/addto --append MODULEPATH /software/easybuild/modules/all)
+export MODULEPATH=$(/easybuild/deps/lmod/lmod/libexec/addto --append MODULEPATH /export/easybuild/modules/all)
 export EASYBUILD_CONFIGFILES=/software/config/config.cfg
 
 module load EasyBuild-develop


### PR DESCRIPTION
Since this is the most popular Docker image in the Docker hub I decided to fix three small issues I encountered when building and running it.

1. Added python-setuptools to the install which fixes an ImportError at runtime of eb (this issue is present in the dockerhub version too).
2. Correct the lmod paths in the z99_StdEnv.sh to  
3. Correct the username in the README from "build" to "easybuild" (which essentially fixes some access denied errors)